### PR TITLE
Tweak to tidy the .json file from building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	@mkdir -p ./_build/html/json
-	@find . -type f -name '*.json' -exec cp -p {} ./_build/html/json/ ";"
+	@find . -type f -name '*.json' -exec mv {} ./_build/html/json/ ";"
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION
@jlstevens Tidy the .json build artifact in the root doc directory for `make html`
