### PR TITLE
Updated CSS to display pandas DataFrame tables nicely

### DIFF
--- a/_shared_static/custom.css
+++ b/_shared_static/custom.css
@@ -366,3 +366,38 @@ ul.tab li input[type="radio"]:checked ~ label {
     background: #902040;
     color: white;
 }
+
+/* CSS for pandas tables (dataframes) */
+
+.rendered_html table {
+    margin-left: auto;
+    margin-right: auto;
+    border: none;
+    border-collapse: collapse;
+    border-spacing: 0;
+    color: black;
+    font-size: 12px;
+    table-layout: fixed;
+}
+.rendered_html tr, .rendered_html th, .rendered_html td {
+    text-align: right;
+    vertical-align: middle;
+    padding: 0.5em 0.5em;
+    line-height: normal;
+    white-space: normal;
+    max-width: none;
+    border: none;
+}
+tbody {
+    display: table-row-group;
+    vertical-align: middle;
+    border-color: inherit;
+}
+.rendered_html tbody tr:nth-child(odd) {
+    background: #f5f5f5;
+}
+
+.rendered_html thead {
+    border-bottom: 1px solid black;
+    vertical-align: bottom;
+}


### PR DESCRIPTION

Improves the CSS so tables (i.e pandas DataFrames) look like:

![image](https://user-images.githubusercontent.com/890576/27055705-2bc6d13c-4fbd-11e7-84af-4fa6cb384be6.png)

Instead of like:

![image](https://user-images.githubusercontent.com/890576/27055750-57d08976-4fbd-11e7-809e-220ab00194c7.png)
