### PR TITLE
The fix_links script now handles gallery links

### DIFF
--- a/fix_links.py
+++ b/fix_links.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """
-Cleans up relative cross-notebook links by replacing them with
-.html extension. 
+Cleans up relative cross-notebook links by replacing them with .html
+extension.
 """
 
 import os
@@ -11,6 +11,11 @@ BOKEH_REPLACEMENTS = {'cell.output_area.append_execute_result':
                       '//cell.output_area.append_execute_result',
                       '}(this));\n</div>': '}(this));\n</script></div>',
                       '\n(function(global) {': '<script>\n(function(global) {'}
+
+# Fix gallery links (e.g to the element gallery)
+LINK_REPLACEMENTS = {'../../examples/elements/':'../gallery/elements/',
+                     '../../examples/demos/':'../gallery/demos/',
+                     '../../examples/streams/':'../gallery/streams/'}
 
 def cleanup_links(path):
     with open(path) as f:
@@ -22,6 +27,8 @@ def cleanup_links(path):
     for a in soup.findAll('a'):
         href = a.get('href', '')
         if '.ipynb' in href and 'http' not in href:
+            for k, v in LINK_REPLACEMENTS.items():
+                href = href.replace(k, v)
             a['href'] = href.replace('.ipynb', '.html')
     html = soup.prettify("utf-8")
     with open(path, 'w') as f:


### PR DESCRIPTION
Needs proper testing but should now handle converting links to element notebooks into gallery links (and similarly for demos and stream examples).